### PR TITLE
doh-update: 09/2021

### DIFF
--- a/doh-domains.txt
+++ b/doh-domains.txt
@@ -3,16 +3,16 @@ adblock.doh.mullvad.net
 adblock.mydns.network
 adfree.usableprivacy.net
 asia.dnscepat.id
+basic.rethinkdns.com
+chrome.cloudflare-dns.com
 cloudflare-dns.com
 commons.host
 de.adhole.org
-dns-asia.wugui.zone
 dns-family.adguard.com
 dns-nyc.aaflalo.me
 dns-unfiltered.adguard.com
 dns-weblock.wevpn.com
 dns.aa.net.uk
-dns.aaflalo.me
 dns.adguard.com
 dns.alidns.com
 dns.api.globus.org
@@ -26,12 +26,10 @@ dns.arapurayil.com
 dns.beta.gandi.net
 dns.blokada.org
 dns.brahma.world
-dns.cfiec.net
 dns.cloudfiction.eu
 dns.cloudflare.com
 dns.cmrg.net
 dns.comss.one
-dns.containerpi.com
 dns.decloudus.com
 dns.digitale-gesellschaft.ch
 dns.dns-over-https.com
@@ -50,7 +48,6 @@ dns.onp.cloud
 dns.oszx.co
 dns.post-factum.tk
 dns.pub
-dns.pumplex.com
 dns.quad9.net
 dns.rubyfish.cn
 dns.switch.ch
@@ -62,7 +59,6 @@ dns.uk-london-1.oraclecloud.com
 dns.us-ashburn-1.oraclecloud.com
 dns.us-phoenix-1.oraclecloud.com
 dns.wevpn.com
-dns.wugui.zone
 dns1.dnscrypt.ca
 dns1.ryan-palmer.com
 dns10.quad9.net
@@ -88,7 +84,6 @@ doh.360.cn
 doh.42l.fr
 doh.applied-privacy.net
 doh.appliedprivacy.net
-doh.armadillodns.net
 doh.au.ahadns.net
 doh.bortzmeyer.fr
 doh.captnemo.in
@@ -109,7 +104,6 @@ doh.ffmuc.net
 doh.ibr.cs.tu-bs.de
 doh.in.ahadns.net
 doh.it.ahadns.net
-doh.kutu.my.id
 doh.la.ahadns.net
 doh.li
 doh.libredns.gr
@@ -121,14 +115,12 @@ doh.northeu.pi-dns.com
 doh.ntu.ssooss.win
 doh.ny.ahadns.net
 doh.opendns.com
-doh.pi-dns.com
 doh.pl.ahadns.net
 doh.post-factum.tk
 doh.powerdns.org
 doh.pub
 doh.qis.io
 doh.seby.io
-doh.this.web.id
 doh.tiar.app
 doh.tiarap.org
 doh.westus.pi-dns.com
@@ -137,6 +129,7 @@ dohdot.coxlab.net
 dohtrial.att.net
 draco.plan9-ns2.com
 ea-dns.rubyfish.cn
+eropa.dnscepat.id
 eu1.dns.lavate.ch
 example.doh.blockerdns.com
 family.canadianshield.cira.ca
@@ -149,7 +142,6 @@ hydra.plan9-ns1.com
 i.233py.com
 ibksturm.synology.me
 ibuki.cgnat.net
-id.terra.my.id
 jcdns.fun
 jit.ddns.net
 jp.tiar.app

--- a/doh-ipv4.txt
+++ b/doh-ipv4.txt
@@ -6,6 +6,10 @@
 172.67.207.222      # adblock.mydns.network
 149.154.153.153     # adfree.usableprivacy.net
 172.105.216.54      # asia.dnscepat.id
+104.21.13.53        # basic.rethinkdns.com
+172.67.154.200      # basic.rethinkdns.com
+104.18.26.211       # chrome.cloudflare-dns.com
+104.18.27.211       # chrome.cloudflare-dns.com
 104.16.248.249      # cloudflare-dns.com
 104.16.249.249      # cloudflare-dns.com
 70.122.22.216       # commons.host
@@ -45,7 +49,6 @@
 51.144.156.129      # dns.comss.one
 81.90.180.173       # dns.comss.one
 92.223.65.71        # dns.comss.one
-93.115.24.204       # dns.comss.one
 176.9.199.158       # dns.decloudus.com
 185.95.218.42       # dns.digitale-gesellschaft.ch
 185.95.218.43       # dns.digitale-gesellschaft.ch
@@ -57,7 +60,7 @@
 91.230.211.67       # dns.east.comss.one
 92.223.109.31       # dns.east.comss.one
 27.112.79.80        # dns.edgy.network
-130.61.2.165        # dns.eu-frankfurt-1.oraclecloud.com
+130.61.0.178        # dns.eu-frankfurt-1.oraclecloud.com
 46.239.223.80       # dns.flatuslifir.is
 8.8.4.4             # dns.google
 8.8.8.8             # dns.google
@@ -85,7 +88,7 @@
 101.102.103.104     # dns.twnic.tw
 132.145.0.172       # dns.uk-london-1.oraclecloud.com
 129.213.0.178       # dns.us-ashburn-1.oraclecloud.com
-129.146.13.150      # dns.us-phoenix-1.oraclecloud.com
+129.146.14.174      # dns.us-phoenix-1.oraclecloud.com
 212.78.94.40        # dns.wevpn.com
 167.114.220.125     # dns1.dnscrypt.ca
 68.183.253.200      # dns1.ryan-palmer.com
@@ -153,7 +156,6 @@
 136.144.215.158     # doh.powerdns.org
 12.159.2.159        # doh.qis.io
 45.76.113.31        # doh.seby.io
-116.0.2.86          # doh.this.web.id
 174.138.29.175      # doh.tiar.app
 104.21.30.162       # doh.tiarap.org
 172.67.173.59       # doh.tiarap.org
@@ -162,6 +164,7 @@
 13.89.120.251       # dohtrial.att.net
 40.76.112.230       # dohtrial.att.net
 45.63.110.187       # draco.plan9-ns2.com
+5.2.75.231          # eropa.dnscepat.id
 95.217.25.217       # eu1.dns.lavate.ch
 35.230.160.38       # example.doh.blockerdns.com
 35.231.247.227      # example.doh.blockerdns.com
@@ -178,8 +181,7 @@
 173.199.126.35      # hydra.plan9-ns1.com
 213.196.191.96      # ibksturm.synology.me
 168.138.243.216     # ibuki.cgnat.net
-104.21.80.136       # id.terra.my.id
-172.67.183.127      # id.terra.my.id
+91.215.155.234      # jcdns.fun
 152.67.165.26       # jit.ddns.net
 172.104.93.80       # jp.tiar.app
 158.64.1.29         # kaitain.restena.lu
@@ -198,8 +200,6 @@
 46.227.200.54       # rdns.faelix.net
 46.227.200.55       # rdns.faelix.net
 51.158.147.50       # resolver-eu.lelux.fi
-104.21.13.53        # rethinkdns.com
-172.67.154.200      # rethinkdns.com
 195.201.220.199     # rumpelsepp.org
 1.0.0.2             # security.cloudflare-dns.com
 1.1.1.2             # security.cloudflare-dns.com

--- a/doh-ipv6.txt
+++ b/doh-ipv6.txt
@@ -4,6 +4,10 @@
 2606:4700:3033::6815:16f3               # adblock.mydns.network
 2606:4700:3037::ac43:cfde               # adblock.mydns.network
 2400:8902::f03c:92ff:fe09:48cc          # asia.dnscepat.id
+2606:4700:3032::6815:d35                # basic.rethinkdns.com
+2606:4700:3036::ac43:9ac8               # basic.rethinkdns.com
+2606:4700::6812:1ad3                    # chrome.cloudflare-dns.com
+2606:4700::6812:1bd3                    # chrome.cloudflare-dns.com
 2606:4700::6810:f8f9                    # cloudflare-dns.com
 2606:4700::6810:f9f9                    # cloudflare-dns.com
 2a10:50c0::bad1:ff                      # dns-family.adguard.com
@@ -95,6 +99,7 @@
 2400:8904:e001:43::43                   # doh.in.ahadns.net
 2a0e:dc0:8:12::12                       # doh.it.ahadns.net
 2a04:bdc7:100:70::70                    # doh.la.ahadns.net
+2a01:4f8:1c0c:8274::1                   # doh.libredns.gr
 2a07:e340::2                            # doh.mullvad.net
 2a04:52c0:101:75::75                    # doh.nl.ahadns.net
 2a0d:5600:30:28::28                     # doh.no.ahadns.net
@@ -112,6 +117,7 @@
 2a04:bdc7:100:70::abcd                  # doh.westus.pi-dns.com
 2001:558:feed:443::99                   # doh.xfinity.com
 2001:19f0:9002:1d74:5400::1             # draco.plan9-ns2.com
+2a04:52c0:101:98d::                     # eropa.dnscepat.id
 2a01:4f9:c01f:74::1                     # eu1.dns.lavate.ch
 2620:10a:80bb::30                       # family.canadianshield.cira.ca
 2620:10a:80bc::30                       # family.canadianshield.cira.ca
@@ -120,12 +126,11 @@
 2a01:4f9:2a:1919::21                    # fi.doh.dns.snopyta.org
 2606:4700:3031::6815:31ea               # free.bravedns.com
 2606:4700:3032::ac43:c394               # free.bravedns.com
+2606:1a40::11                           # freedns.controld.com
 2606:4700:3032::6815:5b69               # i.233py.com
 2606:4700:3037::ac43:d79e               # i.233py.com
 2001:470:b441:2d:12d8:9492:be02:2a83    # ibksturm.synology.me
 2603:c021:c001:31fa::a1c:401            # ibuki.cgnat.net
-2606:4700:3031::6815:5088               # id.terra.my.id
-2606:4700:3033::ac43:b77f               # id.terra.my.id
 2400:8902::f03c:91ff:feda:c514          # jp.tiar.app
 2001:a18:1::29                          # kaitain.restena.lu
 2001:19f0:5001:3a2f:5400:2ff:febd:3b1e  # meganerd.nl
@@ -143,8 +148,6 @@
 2a01:9e01::54                           # rdns.faelix.net
 2a01:9e01::55                           # rdns.faelix.net
 2001:bc8:2db9:100::853                  # resolver-eu.lelux.fi
-2606:4700:3032::6815:d35                # rethinkdns.com
-2606:4700:3036::ac43:9ac8               # rethinkdns.com
 2a01:4f8:1c1c:6938::1                   # rumpelsepp.org
 2606:4700:4700::1002                    # security.cloudflare-dns.com
 2606:4700:4700::1112                    # security.cloudflare-dns.com


### PR DESCRIPTION
* added domains:
  - basic.rethinkdns.com,
  - chrome.cloudflare-dns.com,
  - eropa.dnscepat.id

* removed domains (housekeeping, not available anymore):
  - dns-asia.wugui.zone,
  - dns.aaflalo.me,
  - dns.cfiec.net,
  - dns.containerpi.com,
  - dns.pumplex.com,
  - dns.wugui.zone,
  - doh.armadillodns.net,
  - doh.kutu.my.id,
  - doh.pi-dns.com,
  - doh.this.web.id,
  - id.terra.my.id

Signed-off-by: Dirk Brenken <dev@brenken.org>